### PR TITLE
Always change ip for setup target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,10 @@ envdir={toxworkdir}/acceptance
 setenv =
   CONFIG_PATH = ~/.wazo-acceptance/config.yml
 commands =
-  bash -c 'if [ ! -e {env:CONFIG_PATH} ]; then \
+  bash -c ' \
     mkdir -p $(dirname {env:CONFIG_PATH}); \
     echo -e "default:\n  wazo_host: {posargs}\n" > {env:CONFIG_PATH}; \
-  fi'
+  '
   behave features/pre_daily --verbose
   wazo-acceptance -v -p
 whitelist_externals =


### PR DESCRIPTION
When we run 'tox -e setup' on a new host, setup still use the old IP.

This change ensures we always use the last IP