### PR TITLE
user import: test the wazo-auth "rollback" on import error

### DIFF
--- a/features/daily/user_import.feature
+++ b/features/daily/user_import.feature
@@ -1,0 +1,12 @@
+Feature: CSV import of users
+
+  Scenario: wazo-auth users are not leaked on error
+    Given there are authentication users with info:
+      | firstname | lastname | username | password |
+      | John      | Doe      | john     | lonen0   |
+    When I import the following users ignoring errors:
+      | firstname | lastname | username | password |
+      | One       | Un       | one      | love     |
+      | Two       | Deux     | john     | drag0n   |
+    Then my import result has an error on line "2"
+    Then the user with username "one" does not exist

--- a/wazo_acceptance/helpers/confd_user.py
+++ b/wazo_acceptance/helpers/confd_user.py
@@ -1,6 +1,8 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from requests import HTTPError
+
 
 class ConfdUser:
 
@@ -34,6 +36,12 @@ class ConfdUser:
         if not user:
             raise Exception('Confd user not found: {}'.format(kwargs))
         return user
+
+    def import_users(self, csv):
+        try:
+            return self._confd_client.users.import_csv(csv)
+        except HTTPError as e:
+            return e.response
 
     def _find_by(self, **kwargs):
         users = self._confd_client.users.list(**kwargs)['items']

--- a/wazo_acceptance/steps/user.py
+++ b/wazo_acceptance/steps/user.py
@@ -236,6 +236,5 @@ def when_i_import_users_ignoring_errors(context):
 def then_my_import_result_matches(context, line_number):
     for error in context.import_response['errors']:
         if error['details']['row_number'] == int(line_number):
-            break
-    else:
-        assert False, 'Line number not matched'
+            return
+    raise AssertionError('Line number not matched')

--- a/wazo_acceptance/steps/user.py
+++ b/wazo_acceptance/steps/user.py
@@ -219,3 +219,23 @@ def when_user_does_a_blind_transfer_to_exten_with_api(context, firstname, lastna
         exten=exten,
         flow='blind'
     )
+
+
+@when('I import the following users ignoring errors')
+def when_i_import_users_ignoring_errors(context):
+    lines = [','.join(context.table.headings)]
+    for row in context.table:
+        lines.append(','.join(row))
+    csv = '\n'.join(lines)
+
+    response = context.helpers.confd_user.import_users(csv)
+    context.import_response = response
+
+
+@then('my import result has an error on line "{line_number}"')
+def then_my_import_result_matches(context, line_number):
+    for error in context.import_response['errors']:
+        if error['details']['row_number'] == int(line_number):
+            break
+    else:
+        assert False, 'Line number not matched'


### PR DESCRIPTION
If wazo-auth returns an error during the creation of a user the other valid
users should not be left in the DB without a valid matching ipbx user.

Since a user with username "john" is imported and "john" already exist the other
user "one" should not be created in wazo-auth.

This will allow the admin to fix its CSV and retry or create "one" manually with
getting a 409 because "one" already exist