### PR TITLE
HA: reset slave tenant after first DB replication

### DIFF
--- a/wazo_acceptance/setup.py
+++ b/wazo_acceptance/setup.py
@@ -100,6 +100,7 @@ def setup_websocketd_client(context):
 
 def setup_tenant(context):
     name = context.wazo_config['default_tenant']
+    context.auth_client.set_tenant(None)
     try:
         tenants = context.auth_client.tenants.list(name=name)['items']
     except HTTPError:

--- a/wazo_acceptance/steps/ha.py
+++ b/wazo_acceptance/steps/ha.py
@@ -6,7 +6,7 @@ import string
 
 from behave import given, when, then
 
-from wazo_acceptance import auth
+from wazo_acceptance import auth, setup
 
 
 def random_string(length, sample=string.ascii_lowercase):
@@ -83,6 +83,7 @@ def when_i_start_the_replication_from_instancemaster_to_instanceslave(context, i
     master_context.remote_sysutils.send_command(['xivo-master-slave-db-replication', slave_host], check=True)
     slave_context = getattr(context.instances, instance_slave)
     auth.renew_auth_token(slave_context)
+    setup.setup_tenant(slave_context)
 
 
 @then('there is a user "{username}" on "{instance}"')


### PR DESCRIPTION
Why:

* auth client is still using the old tenant UUID that does not exist
on the slave after DB replication