### PR TITLE
fix presence holding behavior

### DIFF
--- a/features/daily/presence.feature
+++ b/features/daily/presence.feature
@@ -32,9 +32,11 @@ Feature: Presence updated
     Then I receive a "chatd_presence_updated" event with data:
       | line_state |
       | holding    |
-    Then "James Bond" has his line state to "holding"
+    Then "Ti-Me Pare" has his line state to "holding"
+    Then "James Bond" has his line state to "talking"
     When "Ti-Me Pare" resumes his call
     Then I receive a "chatd_presence_updated" event with data:
       | line_state |
       | talking    |
+    Then "Ti-Me Pare" has his line state to "talking"
     Then "James Bond" has his line state to "talking"


### PR DESCRIPTION
reason: with old implementation the holding state was given on the user
held. But to have the same logic as wazo-calld, the holding must be on
the user who make the hold