### PR TITLE
wait process before start transfer

### DIFF
--- a/features/daily/call_transfer.feature
+++ b/features/daily/call_transfer.feature
@@ -17,6 +17,7 @@ Feature: Call transfer
     Then "User A" is ringing
 
     When "User A" answers
+    When I wait 1 seconds for the call processing
     When "User A" does a blind transfer to "1802@default" with API
     When I wait 3 seconds for wazo-calld load to drop
     Then "User B" is ringing
@@ -28,6 +29,7 @@ Feature: Call transfer
     Then "User A" is ringing
 
     When "User A" answers
+    When I wait 1 seconds for the call processing
     When "User A" does a blind transfer to "1804@default" with API
     When I wait 3 seconds for wazo-calld load to drop
     Then "User D" is ringing
@@ -61,6 +63,7 @@ Feature: Call transfer
     Then "User A" is ringing
 
     When "User A" answers
+    When I wait 1 seconds for the call processing
     When "User A" does an attended transfer to "1802@default" with API
     Then "User A" is talking
     Then "incall" is holding

--- a/features/daily/contact-center-stats.feature
+++ b/features/daily/contact-center-stats.feature
@@ -15,19 +15,19 @@ Feature: Stats generation
     When chan_test calls "3521@default" with id "3521-answered"
     When I wait 3 seconds to simulate call center
     When "Stat Agent" answers
-    When I wait 1 seconds to simulate call center
+    When I wait 2 seconds to simulate call center
     When chan_test hangs up channel with id "3521-answered"
 
     # Abandoned call
     When chan_test calls "3521@default" with id "3521-abandoned"
-    When I wait 1 seconds to simulate call center
+    When I wait 2 seconds to simulate call center
     When chan_test hangs up channel with id "3521-abandoned"
 
     # Blocked call
     When I unlog agent "021" from phone
     When I wait 3 seconds for the call processing
     When chan_test calls "3521@default" with id "3521-blocked"
-    When I wait 1 seconds to simulate call center
+    When I wait 2 seconds to simulate call center
     When chan_test hangs up channel with id "3521-blocked"
 
     When I wait 3 seconds for the call processing


### PR DESCRIPTION
reason: asterisk can take some millisecond to bridge call between them
and send events and there is a little range after answer that call
information are not complete in wazo-calld