### PR TITLE
stats: add fields to fuzzy_statistics

### DIFF
--- a/wazo_acceptance/steps/stats.py
+++ b/wazo_acceptance/steps/stats.py
@@ -57,8 +57,8 @@ def then_contact_center_stats_for_agent(context, agent_number):
     for row in context.table:
         expected_stats = row.as_dict()
 
-    fuzzy_statistics = ['conversation_time']
-    fuzziness = 1
+    fuzzy_statistics = ['conversation_time', 'login_time']
+    fuzziness = 2
     for stat_name, expected_value in expected_stats.items():
         if stat_name in fuzzy_statistics:
             expected_value = int(expected_value)


### PR DESCRIPTION
reason: According host, the time to execute action is not the same and
login_time can differ