### PR TITLE
avoid race condition between event and db commit

### DIFF
--- a/wazo_acceptance/steps/bus.py
+++ b/wazo_acceptance/steps/bus.py
@@ -1,8 +1,9 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import collections
 import queue
+import time
 
 from behave import (
     given,
@@ -46,7 +47,13 @@ def then_i_receive_a_event_on_queue(context, event_name):
         assert_that(event, has_key('data'))
         result = _flatten_nested_dict(event['data'])
         assert_that(result, has_entries(context.table[0].as_dict()))
+
     until.assert_(event_match, interval=0.1, tries=10)
+
+    # NOTE(fblackburn): When an event is triggered, the database is not committed. Sometime, a
+    # race condition can occur (mostly on single core host) between the event sent and the
+    # database commit. Adding delay help to avoid this race condition.
+    time.sleep(0.1)
 
 
 @then('I receive a "{event_name}" event with "{wrapper}" data')

--- a/wazo_acceptance/steps/presence.py
+++ b/wazo_acceptance/steps/presence.py
@@ -4,8 +4,6 @@
 from behave import then
 from hamcrest import assert_that, equal_to
 
-from xivo_test_helpers import until
-
 
 @then('"{firstname} {lastname}" has "{nb_session}" session in his presence')
 def then_the_user_has_number_session_from_his_presence(context, firstname, lastname, nb_session):
@@ -17,12 +15,5 @@ def then_the_user_has_number_session_from_his_presence(context, firstname, lastn
 @then('"{firstname} {lastname}" has his line state to "{line_state}"')
 def then_the_user_has_his_line_state_to(context, firstname, lastname, line_state):
     user = context.helpers.user.get_by(firtname=firstname, lastname=lastname)
-
-    def check_line_state():
-        presence = context.chatd_client.user_presences.get(user['uuid'])
-        assert_that(presence['line_state'], equal_to(line_state))
-
-    # NOTE(fblackburn): When this step is executed after the event received step, then a race
-    # condition can occurs (mostly on single core host) between the event sent and the database
-    # commit
-    until.assert_(check_line_state, interval=0.2, tries=2)
+    presence = context.chatd_client.user_presences.get(user['uuid'])
+    assert_that(presence['line_state'], equal_to(line_state))


### PR DESCRIPTION
this race condition has been found in presence and call log recording.