### PR TITLE
Pull request for fix-flaky-test

### DIFF
--- a/features/daily/call_record.feature
+++ b/features/daily/call_record.feature
@@ -11,7 +11,7 @@ Feature: Call Record
     When a call is started:
       | caller   | dial | callee   | talk_time | hangup |
       | User 800 | 1801 | User 801 | 3         | callee |
-    Then I receive a "call_log_created" event:
+    Then I receive a "call_log_created" event with data:
       | source_name | destination_name |
       | User 800    | User 801         |
     Then "User 800" has no call recording
@@ -26,7 +26,7 @@ Feature: Call Record
     When a call is started:
       | caller   | dial | callee   | talk_time | hangup |
       | User 800 | 1801 | User 801 | 3         | callee |
-    Then I receive a "call_log_created" event:
+    Then I receive a "call_log_created" event with data:
       | source_name | destination_name |
       | User 800    | User 801         |
     Then "User 800" has a call recording with "User 801"
@@ -45,7 +45,7 @@ Feature: Call Record
     When "User 800" starts call recording
     When I wait 1 seconds for the call processing
     When "User 801" hangs up
-    Then I receive a "call_log_created" event:
+    Then I receive a "call_log_created" event with data:
       | source_name | destination_name |
       | User 800    | User 801         |
     Then "User 800" has 2 call recordings with "User 801"

--- a/wazo_acceptance/steps/bus.py
+++ b/wazo_acceptance/steps/bus.py
@@ -43,6 +43,11 @@ def then_i_receive_a_message(context, event_name):
     events = context.helpers.bus.pop_received_event()
     assert_that(events, has_entries(name=event_name))
 
+    # NOTE(fblackburn): When an event is triggered, the database is not committed. Sometime, a
+    # race condition can occur (mostly on single core host) between the event sent and the
+    # database commit. Adding delay help to avoid this race condition.
+    time.sleep(0.1)
+
 
 @then('I receive a "{event_name}" event with data')
 def then_i_receive_a_event_on_queue(context, event_name):
@@ -67,6 +72,11 @@ def then_i_receive_a_event_with_wrapper_on_queue(context, event_name, wrapper):
     assert_that(event, has_entries(name=event_name, data=has_key(wrapper)))
     result = _flatten_nested_dict(event['data'][wrapper])
     assert_that(result, has_entries(context.table[0].as_dict()))
+
+    # NOTE(fblackburn): When an event is triggered, the database is not committed. Sometime, a
+    # race condition can occur (mostly on single core host) between the event sent and the
+    # database commit. Adding delay help to avoid this race condition.
+    time.sleep(0.1)
 
 
 def _flatten_nested_dict(dict_, parent_key='', separator='_'):

--- a/wazo_acceptance/steps/bus.py
+++ b/wazo_acceptance/steps/bus.py
@@ -25,7 +25,7 @@ def given_i_listen_on_the_bus_for_messages(context, event_name):
 
 
 @given('I listen on the bus for the following events')
-def given_i_listen_on_the_bus_for_messages(context):
+def given_i_listen_on_the_bus_for_the_following_events(context):
     context.helpers.bus.subscribe([event['event'] for event in context.table])
 
 


### PR DESCRIPTION
## fix duplicate function name


## add delays after bus event reception in more cases

Why:

* Avoid flaky tests using bus events for synchronization
* Last example: Default call with extension callrecord enabled

Then "User 800" has no call recording                     # wazo_acceptance/steps/user.py:428
  Traceback (most recent call last):
    File "/var/lib/jenkins/workspace/daily-acceptance/wazo-acceptance-venv/lib/python3.7/site-packages/behave/model.py", line 1329, in run
      match.run(runner.context)
    File "/var/lib/jenkins/workspace/daily-acceptance/wazo-acceptance-venv/lib/python3.7/site-packages/behave/matchers.py", line 98, in run
      self.func(context, *args, **kwargs)
    File "/var/lib/jenkins/workspace/daily-acceptance/wazo_acceptance/steps/user.py", line 432, in then_user_has_no_call_recording
      assert cdr[0]['source_user_uuid'] == user['uuid']
  IndexError: list index out of range