### PR TITLE
bsfilter: increase funckey processing time

### DIFF
--- a/features/daily/bsfilter.feature
+++ b/features/daily/bsfilter.feature
@@ -20,7 +20,8 @@ Feature: Boss Secretary Filter
       | position | destination_type | destination_filter_name | destination_filter_member |
       | 1        | bsfilter         | Charlie's Angels        | Angel 001                 |
     When "Charlie Unknown" press function key "1"
-    When I wait 4 seconds for the call processing
+    When I wait 2 seconds for the call processing
+    When I wait 3 seconds to play message
     Then "Charlie Unknown" has function key "1" hint enabled
     Then "Angel 001" has function key "1" hint enabled
     When "Bad Guy" calls "1001"
@@ -30,7 +31,8 @@ Feature: Boss Secretary Filter
     When "Bad Guy" hangs up
 
     When "Charlie Unknown" press function key "1"
-    When I wait 4 seconds for the call processing
+    When I wait 2 seconds for the call processing
+    When I wait 3 seconds to play message
     Then "Charlie Unknown" has function key "1" hint disabled
     Then "Angel 001" has function key "1" hint disabled
     When "Bad Guy" calls "1001"
@@ -40,7 +42,8 @@ Feature: Boss Secretary Filter
     When "Bad Guy" hangs up
     
     When "Angel 001" press function key "1"
-    When I wait 4 seconds for the call processing
+    When I wait 2 seconds for the call processing
+    When I wait 3 seconds to play message
     Then "Charlie Unknown" has function key "1" hint enabled
     Then "Angel 001" has function key "1" hint enabled
     When "Bad Guy" calls "1001"
@@ -50,7 +53,8 @@ Feature: Boss Secretary Filter
     When "Bad Guy" hangs up
 
     When "Angel 001" press function key "1"
-    When I wait 4 seconds for the call processing
+    When I wait 2 seconds for the call processing
+    When I wait 3 seconds to play message
     Then "Charlie Unknown" has function key "1" hint disabled
     Then "Angel 001" has function key "1" hint disabled
     When "Bad Guy" calls "1001"

--- a/wazo_acceptance/steps/time.py
+++ b/wazo_acceptance/steps/time.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -26,6 +26,7 @@ def given_no_hour_change_in_next_1_seconds(context, seconds):
 @when('I wait {seconds} seconds for the timeout to not expire')
 @when('I wait {seconds} seconds for wazo-calld load to drop')
 @when('I wait {seconds} seconds to play unreachable message')
+@when('I wait {seconds} seconds to play message')
 @when('I wait {seconds} seconds to simulate call center')
 @when('I wait {seconds} seconds until the wrapup completes')
 @when('I wait {seconds} seconds while being logged on')


### PR DESCRIPTION
reason: a fail occurs because the channel was hangup automatically (by
the end of message) AFTER making a call to the same person. Then, last
linphone active channel is not the right one