### PR TITLE
add sleep after hangup and before recalling

### DIFF
--- a/features/daily/group.feature
+++ b/features/daily/group.feature
@@ -38,6 +38,7 @@ Feature: Groups
     When I wait 2 seconds for the call processing
     Then "Flash McQueen" is ringing
     Then "Tow Mater" hangs up
+    When I wait 1 seconds for the call hangs up for everyone
     When "Flash McQueen" press function key "1"
     When I wait 4 seconds for the call processing
     When "Tow Mater" calls "2801"

--- a/wazo_acceptance/steps/time.py
+++ b/wazo_acceptance/steps/time.py
@@ -17,6 +17,7 @@ def given_no_hour_change_in_next_1_seconds(context, seconds):
 
 
 @when('I wait {seconds} seconds during my pause')
+@when('I wait {seconds} seconds for the call hangs up for everyone')
 @when('I wait {seconds} seconds for the call processing with slow machine')
 @when('I wait {seconds} seconds for the call processing')
 @when('I wait {seconds} seconds for the call to be forwarded')


### PR DESCRIPTION
reason: it can have a small delay when someone hangs up and asterisk
hangup all other channel. Then linphone will fail to call a number if
the current phone state is ringing or talking