### PR TITLE
add small delay before trying a new transfer

### DIFF
--- a/features/daily/call_transfer.feature
+++ b/features/daily/call_transfer.feature
@@ -89,6 +89,7 @@ Feature: Call transfer
     Then "incall" is talking
     Then "User B" is hungup
 
+    When I wait 0.5 seconds for the transfer lock release
     When "User A" does an attended transfer to "1850@default" with API
     When "User A" complete the transfer with API
     Then "User A" is hungup

--- a/wazo_acceptance/steps/time.py
+++ b/wazo_acceptance/steps/time.py
@@ -26,6 +26,7 @@ def given_no_hour_change_in_next_1_seconds(context, seconds):
 @when('I wait {seconds} seconds for the no permission message to complete')
 @when('I wait {seconds} seconds for the timeout to expire')
 @when('I wait {seconds} seconds for the timeout to not expire')
+@when('I wait {seconds} seconds for the transfer lock release')
 @when('I wait {seconds} seconds for wazo-calld load to drop')
 @when('I wait {seconds} seconds to play unreachable message')
 @when('I wait {seconds} seconds to play message')


### PR DESCRIPTION
reason: it can take some milliseconds to release the transfer lock and
be able to make a new transfer