### PR TITLE
Pull request for WAZO-2422-switchboard-fallback-noanswer

### DIFF
--- a/features/daily/switchboard.feature
+++ b/features/daily/switchboard.feature
@@ -36,3 +36,52 @@ Feature: Switchboards
       | incall                |
     # NOTE(fblackburn): Ideally, the phone will support PAI header
     Then "Manager Inn" is talking to "incall" from API
+
+  Scenario: Timeout
+    Given there are telephony users with infos:
+      | firstname | lastname | exten | context | with_phone | with_token |
+      | Reception | Clerk    | 1801  | default | yes        | yes        |
+    Given there are switchboards with infos:
+        | name                 | members         | timeout | noanswer_destination |
+        | timeout              | Reception Clerk |      15 | hangup:              |
+        | no-timeout           |                 |         | hangup:              |
+        | no-fallback          |                 |       1 |                      |
+        | transfer-destination |                 |         |                      |
+
+    Given there is an incall "1001@from-extern" to the switchboard "timeout"
+    Given there is an incall "1002@from-extern" to the switchboard "no-timeout"
+    Given there is an incall "1003@from-extern" to the switchboard "no-fallback"
+    Given there is an incall "1004@from-extern" to the switchboard "transfer-destination"
+
+    When incoming call received from "i-will-timeout" to "1001@from-extern"
+    When incoming call received from "i-will-not-timeout-1" to "1002@from-extern"
+    When incoming call received from "i-will-not-timeout-2" to "1003@from-extern"
+    When incoming call received from "i-will-be-transferred-to-switchboard" to "1001@from-extern"
+    When incoming call received from "i-will-be-answered" to "1001@from-extern"
+    When I wait 2 seconds for the call processing
+
+    # Transfer call to another switchboard
+    Then switchboard "timeout" has "i-will-be-transferred-to-switchboard" in queued calls
+    When "Reception Clerk" answer queued call "i-will-be-transferred-to-switchboard" from switchboard "timeout"
+    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
+    When "Reception Clerk" answers
+    Then "Reception Clerk" is talking to "i-will-be-transferred-to-switchboard"
+    When I wait 1 seconds for the call processing
+    When "Reception Clerk" does a blind transfer to "1004@from-extern" with API
+
+    # Answer next call
+    Then switchboard "timeout" has "i-will-be-answered" in queued calls
+    When "Reception Clerk" answer queued call "i-will-be-answered" from switchboard "timeout"
+    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
+    When "Reception Clerk" answers
+
+    When I wait 10 seconds for the timeout to expire
+
+    Then "Reception Clerk" is talking to "i-will-be-answered" from API
+    Then "i-will-timeout" is hungup
+    Then switchboard "no-timeout" has "i-will-not-timeout-1" in queued calls
+    Then switchboard "no-fallback" has "i-will-not-timeout-2" in queued calls
+
+    # Should be Caller ID "i-will-be-transferred-to-switchboard", 
+    # but is "Reception Clerk" due to an Asterisk bug on Local channels
+    Then switchboard "transfer-destination" has "Reception Clerk" in queued calls

--- a/features/daily/switchboard.feature
+++ b/features/daily/switchboard.feature
@@ -14,16 +14,12 @@ Feature: Switchboards
     Then I receive a "switchboard_queued_calls_updated" event
     Then switchboard "Inn" has "incall" in queued calls
     When "Reception Clerk" answer queued call "incall" from switchboard "Inn"
-    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
-    When "Reception Clerk" answers
     Then "Reception Clerk" is talking to "incall"
 
     When I wait 1 seconds for the call processing
     When "Reception Clerk" put call "incall" from switchboard "Inn" on hold
     Then switchboard "Inn" has "incall" in held calls
     When "Reception Clerk" answer held call "incall" from switchboard "Inn"
-    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
-    When "Reception Clerk" answers
     Then "Reception Clerk" is talking to "incall"
 
     When I wait 1 seconds for the call processing
@@ -63,8 +59,6 @@ Feature: Switchboards
     # Transfer call to another switchboard
     Then switchboard "timeout" has "i-will-be-transferred-to-switchboard" in queued calls
     When "Reception Clerk" answer queued call "i-will-be-transferred-to-switchboard" from switchboard "timeout"
-    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
-    When "Reception Clerk" answers
     Then "Reception Clerk" is talking to "i-will-be-transferred-to-switchboard"
     When I wait 1 seconds for the call processing
     When "Reception Clerk" does a blind transfer to "1004@from-extern" with API
@@ -72,8 +66,6 @@ Feature: Switchboards
     # Answer next call
     Then switchboard "timeout" has "i-will-be-answered" in queued calls
     When "Reception Clerk" answer queued call "i-will-be-answered" from switchboard "timeout"
-    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
-    When "Reception Clerk" answers
 
     When I wait 10 seconds for the timeout to expire
 

--- a/wazo_acceptance/steps/switchboard.py
+++ b/wazo_acceptance/steps/switchboard.py
@@ -9,26 +9,40 @@ def given_there_are_switchboards_with_infos(context):
     context.table.require_columns(['name'])
     for row in context.table:
         body = row.as_dict()
+        timeout = body.pop('timeout', None)
+        if timeout:
+            body['timeout'] = int(timeout)
         switchboard = context.helpers.switchboard.create(body)
         members = body['members'].split(',') if body.get('members') else []
         users = [context.helpers.confd_user.get_by(fullname=name) for name in members]
         context.confd_client.switchboards(switchboard).update_user_members(users)
+
+        if body.get('noanswer_destination'):
+            type_, name = body['noanswer_destination'].split(':')
+            fallbacks_body = {'noanswer_destination': {'type': type_}}
+            if type_ == 'hangup':
+                fallbacks_body['noanswer_destination']['cause'] = 'normal'
+            else:
+                raise NotImplementedError('Destination not implemented: {}'.format(type_))
+            context.confd_client.switchboards(switchboard).update_fallbacks(fallbacks_body)
 
 
 @then('switchboard "{name}" has "{caller_name}" in queued calls')
 def then_switchboard_has_callerid_in_queued_calls(context, name, caller_name):
     switchboard = context.helpers.switchboard.get_by(name=name)
     calls = context.calld_client.switchboards.list_queued_calls(switchboard['uuid'])
-    caller_names = [call['caller_id_number'] for call in calls['items']]
-    assert caller_name in caller_names
+    caller_numbers = [call['caller_id_number'] for call in calls['items']]
+    caller_names = [call['caller_id_name'] for call in calls['items']]
+    assert caller_name in (caller_names + caller_numbers)
 
 
 @then('switchboard "{name}" has "{caller_name}" in held calls')
 def then_switchboard_has_callerid_in_held_calls(context, name, caller_name):
     switchboard = context.helpers.switchboard.get_by(name=name)
     calls = context.calld_client.switchboards.list_held_calls(switchboard['uuid'])
-    caller_names = [call['caller_id_number'] for call in calls['items']]
-    assert caller_name in caller_names
+    caller_numbers = [call['caller_id_number'] for call in calls['items']]
+    caller_names = [call['caller_id_name'] for call in calls['items']]
+    assert caller_name in (caller_names + caller_numbers)
 
 
 @when('"{firstname} {lastname}" answer queued call "{caller_name}" from switchboard "{name}"')

--- a/wazo_acceptance/steps/switchboard.py
+++ b/wazo_acceptance/steps/switchboard.py
@@ -61,6 +61,10 @@ def when_user_answer_queued_call_from_switchboard(context, firstname, lastname, 
             call['id'],
         )
 
+    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
+    phone = context.phone_register.get_phone(tracking_id)
+    phone.answer()
+
 
 @when('"{firstname} {lastname}" answer held call "{caller_name}" from switchboard "{name}"')
 def when_user_answer_held_call_from_switchboard(context, firstname, lastname, caller_name, name):
@@ -76,6 +80,10 @@ def when_user_answer_held_call_from_switchboard(context, firstname, lastname, ca
             switchboard['uuid'],
             call['id']
         )
+
+    # NOTE(fblackburn): Ideally, the phone will support auto answer headers
+    phone = context.phone_register.get_phone(tracking_id)
+    phone.answer()
 
 
 @when('"{firstname} {lastname}" put call "{caller_name}" from switchboard "{name}" on hold')


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/125
Depends-On: https://github.com/wazo-platform/wazo-confd-client/pull/28
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/75
Depends-On: https://github.com/wazo-platform/xivo-manage-db/pull/121
Depends-On: https://github.com/wazo-platform/wazo-calld/pull/189
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/82
Depends-On: https://github.com/wazo-platform/xivo-config/pull/53
Depends-On: https://github.com/wazo-platform/wazo-confd/pull/208

## switchboards: assert caller id number AND name

Why:

* Makes steps more readable with callerid name

## switchboards: test no answer timeout


## switchboards: make implicit the answering of queued call

Why:

* Avoid duplication of "phone answers" step