### PR TITLE
chan test: raise an exception if chan test is not loaded

### DIFF
--- a/wazo_acceptance/helpers/asterisk.py
+++ b/wazo_acceptance/helpers/asterisk.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -8,7 +8,10 @@ class Asterisk:
         self._ssh_client = ssh_client
 
     def send_to_asterisk_cli(self, asterisk_command):
-        return self._ssh_client.out_call(self._format_command(asterisk_command))
+        response = self._ssh_client.out_call(self._format_command(asterisk_command))
+        if asterisk_command.startswith('test ') and response.startswith("No such command 'test"):
+            raise Exception('chan_test.so needs to be loaded on the stack')
+        return response
 
     def _format_command(self, asterisk_command):
         return ['asterisk', '-rx', '"{}"'.format(asterisk_command)]


### PR DESCRIPTION
I spent too searching why nothing happened in Asterisk (with all the noise from
the reloads and the phones getting registered) to allow someone else to try to
run the tests without chan_test loaded on there stack.