### PR TITLE
fix race condition between event and listening

### DIFF
--- a/wazo_acceptance/helpers/bus.py
+++ b/wazo_acceptance/helpers/bus.py
@@ -1,12 +1,14 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import functools
 import queue
 import threading
+
 from contextlib import contextmanager
 from hamcrest import assert_that, has_entries
+from wazo_test_helpers import until
 
 logger = logging.getLogger(__name__)
 tasks = None
@@ -104,6 +106,8 @@ class Bus:
                 functools.partial(self._save_event, event)
             )
         self._start()
+        until.true(lambda: self._websocketd_client._is_running, interval=0.5, tries=10)
+
         self._context.add_cleanup(self._stop)
 
     def _save_event(self, name, event):


### PR DESCRIPTION
    why: starting to listen on bus can take a small delay (~0.5s) to
    exchange init messages (subscribe + init + start) on loaded host and
    really receive messages
    
    The failing test was presence holding
    It happens because the host was under heavy load by a regression

I don't want to merge this code until a "good" reason, because for now, it founds a performance regression
see: https://wazo-dev.atlassian.net/browse/WAZO-2816