### PR TITLE
pin importlib_metadata package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 PyHamcrest
 SQLAlchemy
 behave
+importlib_metadata==1.6.0  # from kombu
 kombu==4.6.11
 psycopg2
 python-consul==0.7.1


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version (5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version