### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-skipsdist=True
+skipsdist = false
 envlist = pycodestyle, pylint
 
 [testenv]
 basepython = python3.7
-usedevelop = true
+use_develop = true
 passenv =
     SSH_AUTH_SOCK
 deps =
@@ -21,7 +21,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_acceptance > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:pylint]
@@ -30,7 +30,7 @@ commands =
 deps =
     -rrequirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:setup]
@@ -46,7 +46,7 @@ commands =
   fi'
   behave features/pre_daily --verbose
   wazo-acceptance -v -p
-whitelist_externals =
+allowlist_externals =
   bash
   docker
 


### PR DESCRIPTION
Why:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals