### PR TITLE
avoid race condition with hold step

### DIFF
--- a/features/ha/high_availability.feature
+++ b/features/ha/high_availability.feature
@@ -6,12 +6,12 @@ Feature: High availability
     Then the file "/etc/cron.d/xivo-ha-master" does not exist on "master"
     When I enable the HA as master on "master"
     Then there are cron jobs in "/etc/cron.d/xivo-ha-master" on "master"
-    | cron job                                                                              |
-    | 0 * * * * root /usr/sbin/xivo-master-slave-db-replication {{ slave_voip_ip_address }} |
-    | 0 * * * * root /usr/bin/xivo-sync                                                     |
+      | cron job                                                                              |
+      | 0 * * * * root /usr/sbin/xivo-master-slave-db-replication {{ slave_voip_ip_address }} |
+      | 0 * * * * root /usr/bin/xivo-sync                                                     |
     Then the provd config "default" has the following values on "master"
-    | X_type    | proxy_backup                | registrar_backup            |
-    | registrar | {{ slave_voip_ip_address }} | {{ slave_voip_ip_address }} |
+      | X_type    | proxy_backup                | registrar_backup            |
+      | registrar | {{ slave_voip_ip_address }} | {{ slave_voip_ip_address }} |
 
   Scenario: Enable/disable HA slave changes cron jobs
     Given the HA is enabled as slave on "slave"
@@ -19,11 +19,11 @@ Feature: High availability
     Then the file "/etc/cron.d/xivo-ha-slave" does not exist on "slave"
     When I enable the HA as slave on "slave"
     Then there are cron jobs in "/etc/cron.d/xivo-ha-slave" on "slave"
-    | cron job                                                                       |
-    | * * * * * root /usr/sbin/xivo-check-master-status {{ master_voip_ip_address }} |
+      | cron job                                                                       |
+      | * * * * * root /usr/sbin/xivo-check-master-status {{ master_voip_ip_address }} |
     Then the provd offline config "default" has the following values on "slave"
-    | X_type    | proxy_backup | registrar_backup |
-    | registrar |              |                  |
+      | X_type    | proxy_backup | registrar_backup |
+      | registrar |              |                  |
 
   Scenario: HA synchronization
     Given the HA is enabled as master on "master"

--- a/wazo_acceptance/steps/phone_call.py
+++ b/wazo_acceptance/steps/phone_call.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import time
@@ -121,6 +121,8 @@ def step_a_calls_exten_and_waits_for_x_seconds(context, tracking_id, exten, time
 def step_user_puts_call_on_hold(context, tracking_id):
     phone = context.phone_register.get_phone(tracking_id)
     phone.hold()
+    # Leave time to asterisk to switch RTP to music
+    time.sleep(0.5)
 
 
 @step('"{tracking_id}" resumes his call')


### PR DESCRIPTION
## avoid race condition with hold step

why:  When exeucting another call step after this one, ex:

```
When "Maggie Greene" puts his call on hold
When "Maggie Greene" resumes his call
```

We can have a race condition that call is not totally switched to on
hold state

## fix styling issues
