### PR TITLE
ha: wait until services are ready after restart

### DIFF
--- a/features/ha/high_availability.feature
+++ b/features/ha/high_availability.feature
@@ -37,6 +37,7 @@ Feature: High availability
 
     # Workaround WAZO-2999
     Then I execute "wazo-service restart" command on "slave"
+    Then I wait until services are ready on "slave"
 
   Scenario: HA files synchronization
     Given the HA is enabled as master on "master"


### PR DESCRIPTION
why: otherwise calling endpoint that require master tenant will fail
with error 503