### PR TITLE
reduce delay between sound playing check

### DIFF
--- a/wazo_acceptance/steps/phone_call.py
+++ b/wazo_acceptance/steps/phone_call.py
@@ -256,7 +256,8 @@ def then_user_hears_the_sound_file(context, tracking_id, sound_file_name):
     until.assert_(
         _sound_is_playing, context, channel_id, sound_file_name,
         timeout=8,
-        message=f'The sound {sound_file_name} is not playing'
+        interval=0.5,
+        message=f'The sound {sound_file_name} is not playing',
     )
 
 


### PR DESCRIPTION
why: because vm-goodbye take ~1 sec to be played and in some rare
condition, the check can skip the whole playback