### PR TITLE
asterisk queuelog: make EXITWITHTIMEOUT more reliable

### DIFF
--- a/features/daily/integration-asterisk-queuelog.feature
+++ b/features/daily/integration-asterisk-queuelog.feature
@@ -181,13 +181,12 @@ Feature: Stats generation
           | name | exten | context | timeout | option_timeout | agents | 
           | q12  | 3512  | default | 10      | 5              | 012    |
         Given agent "012" is logged
-        When chan_test calls "3512@default" with id "3512-1"
+        When chan_test calls "3512@default" with caller ID name "3512-1"
         # Only the first call needs time to be processed to reach the agent
         When I wait 2 seconds for the call processing
-        When chan_test calls "3512@default" with id "3512-2"
-        When I wait 12 seconds for the timeout to expire
-        When chan_test hangs up channel with id "3512-1"
-        When chan_test hangs up channel with id "3512-2"
+        When chan_test calls "3512@default" with caller ID name "3512-2"
+        When I wait until call with caller ID name "3512-1" to be over
+        When I wait until call with caller ID name "3512-2" to be over
         Then queue_log contains 2 "EXITWITHTIMEOUT" events for queue "q12"
 
     Scenario: 13 Generate corrupt stats

--- a/wazo_acceptance/helpers/call.py
+++ b/wazo_acceptance/helpers/call.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 _UNDEFINED = object()
@@ -11,7 +11,7 @@ class Call:
         self._calld_client = context.calld_client
 
     def get_by(self, **kwargs):
-        call = self._find_by(**kwargs)
+        call = self.find_by(**kwargs)
         if not call:
             raise Exception('Call not found: {}'.format(kwargs))
         return call
@@ -22,7 +22,7 @@ class Call:
     def start_recording(self, call_id):
         self._calld_client.calls.start_record(call_id)
 
-    def _find_by(self, **kwargs):
+    def find_by(self, **kwargs):
         user_uuid = kwargs.pop('user_uuid', _UNDEFINED)
         caller_id_number = kwargs.pop('caller_id_number', _UNDEFINED)
         caller_id_name = kwargs.pop('caller_id_name', _UNDEFINED)

--- a/wazo_acceptance/steps/phone_call.py
+++ b/wazo_acceptance/steps/phone_call.py
@@ -181,6 +181,12 @@ def when_chan_test_calls_with_id(context, exten, exten_context, channel_id):
     context.helpers.asterisk.send_to_asterisk_cli(cmd)
 
 
+@when('chan_test calls "{exten}@{exten_context}" with caller ID name "{cid_name}"')
+def when_chan_test_calls_with_id(context, exten, exten_context, cid_name):
+    cmd = f'test new {exten} {exten_context} chan-test-num {cid_name} {CHAN_PREFIX}'
+    context.helpers.asterisk.send_to_asterisk_cli(cmd)
+
+
 @when('chan_test places calls in order')
 def when_chan_test_places_calls_in_order(context):
     for call in context.table:

--- a/wazo_acceptance/steps/time.py
+++ b/wazo_acceptance/steps/time.py
@@ -19,13 +19,10 @@ def given_no_hour_change_in_next_1_seconds(context, seconds):
 
 
 @when('I wait until call with caller ID name "{cid_name}" to be over')
-def step_impl(context, cid_name):
+def when_i_wait_until_call_with_caller_id_name_to_be_over(context, cid_name):
     def call_is_up():
-        calls = context.calld_client.calls.list_calls()
-        for call in calls['items']:
-            if call['caller_id_name'] == cid_name:
-                return True
-        return False
+        call = context.helpers.call.find_by(caller_id_name=cid_name)
+        return call is not None
 
     until.false(
         call_is_up,


### PR DESCRIPTION
Queue timeouts are hard to predict. The queue has a timeout that will hangup a call when this timeout is reached. But there's also a timeout on call distribution. If a call is being distributed to an agent the call will NOT timeout until the agent timeout happens.

It is possible to spend more time than TIMEOUT in a queue before the EXITTIMEOUT depending on the time at which you enter a call distribution loop.

In this scenario the agent is being distributed the first call then after 14 seconds the caller hangs up which is unnecessary because the queue already dropped this call.

When the second call enters the queue the distribution loop could send call 1 OR call 2 to the agent and this is where it gets unpredictable.

I changed the test to leave the call in the queue until the timeout happens instead of trying to hang up once the timeout has been reached and generating an abandonned call every once in a while