### PR TITLE
Remove workaround for jit as it is now permanent

### DIFF
--- a/wazo_acceptance/prerequisite.py
+++ b/wazo_acceptance/prerequisite.py
@@ -301,16 +301,6 @@ def _configure_postgresql_debug(context):
         config_file,
     ]
     context.ssh_client.check_call(command)
-    # FIXME(fblackburn): Temporary disable JIT to try to improve performance
-    # Should be disable on the whole wazo if it fix performance issue
-    command = [
-        'sed',
-        '-i',
-        '-E',
-        '"s/#jit = (on|off)/jit = off/"',
-        config_file,
-    ]
-    context.ssh_client.check_call(command)
     pg_is_running = context.remote_sysutils.is_process_running('postgresql@13-main')
     if pg_is_running:
         context.remote_sysutils.reload_service('postgresql')


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-dbms/pull/10
Depends-on: https://github.com/wazo-platform/wazo-upgrade/pull/77