### PR TITLE
enable debug log on wazo-sysconfd

### DIFF
--- a/wazo_acceptance/prerequisite.py
+++ b/wazo_acceptance/prerequisite.py
@@ -29,6 +29,7 @@ WAZO_SERVICES = [
     'wazo-phoned',
     'wazo-plugind',
     'wazo-provd',
+    'wazo-sysconfd',
     'wazo-webhookd',
     'wazo-websocketd',
 ]


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-sysconfd/pull/83
why: to see when the asterisk reload event is sent
Edit: Since this PR will help to debug failing tests, we should merge it without waiting for success