### PR TITLE
Pull request for jenkins-cleanup-workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
   stages {
     stage ('Prepare') {
       steps {
+        cleanWs()
         script {
           helpers = load('./jenkins/helpers.groovy')
         }

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -23,11 +23,11 @@ debug:
   wazo_test_helpers: True
 EOF
 
-set -xe -o pipefail
-
 VENV=wazo-acceptance-venv
 python3.9 -m venv --clear $VENV
+set +x
 source $VENV/bin/activate
+set -x
 pip install wheel
 
 pip install -r requirements.txt

--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -26,7 +26,7 @@ EOF
 set -xe -o pipefail
 
 VENV=wazo-acceptance-venv
-python3.9 -m venv $VENV
+python3.9 -m venv --clear $VENV
 source $VENV/bin/activate
 pip install wheel
 


### PR DESCRIPTION
## jenkins: clear virtualenv

Why:

* Avoid reusing old libraries

## jenkins: clear workspace before running

Why:

* avoid any possible conflicts with older files

## jenkins: improve shell options

Why:

* set instructions was duplicated
* sourcing virtualenv adds a lot of noise in the logs