### PR TITLE
Allow custom host configuration for ARI/BUS/SSH

### DIFF
--- a/features/daily/http.feature
+++ b/features/daily/http.feature
@@ -19,6 +19,7 @@ Feature: HTTP
     | GET    | /api/webhookd/1.0/config     |
     | GET    | /api/websocketd/             |
 
+  @rate-limit
   Scenario Outline: Unauthenticated HTTP resources are throttled
     Then "<method>" "<url>" eventually receive the answer 429 instead of "<status_code>"
 

--- a/features/daily/http.feature
+++ b/features/daily/http.feature
@@ -18,7 +18,6 @@ Feature: HTTP
     | GET    | /api/provd/0.2/configure     |
     | GET    | /api/webhookd/1.0/config     |
     | GET    | /api/websocketd/             |
-    | GET    | :9499/0.1/config             |
 
   Scenario Outline: Unauthenticated HTTP resources are throttled
     Then "<method>" "<url>" eventually receive the answer 429 instead of "<status_code>"

--- a/wazo_acceptance/config.py
+++ b/wazo_acceptance/config.py
@@ -143,5 +143,8 @@ def _config_update_host(config):
     for service in services:
         config[service].setdefault('host', wazo_host)
 
+    # Useful when HTTP are proxied by not provisioning server
+    config['provd'].setdefault('provisioning_host', wazo_host)
+
     ari_host = config['ari'].pop('host')
     config['ari']['base_url'] = f"http://{ari_host}:5039"

--- a/wazo_acceptance/config.py
+++ b/wazo_acceptance/config.py
@@ -66,7 +66,9 @@ DEFAULT_INSTANCE_CONFIG = {
     'websocketd': {
         'verify_certificate': False,
     },
-    'ssh_login': 'root',
+    'ssh': {
+        'login': 'root',
+    },
     'linphone': {
         'sip_port_range': '5001,5009',
         'rtp_port_range': '5100,5120',
@@ -126,6 +128,7 @@ def _config_update_host(config):
         'agentd',
         'amid',
         'auth',
+        'ari',
         'call_logd',
         'calld',
         'chatd',
@@ -133,10 +136,12 @@ def _config_update_host(config):
         'dird',
         'provd',
         'setupd',
+        'ssh',
         'bus',
         'websocketd',
     )
     for service in services:
         config[service].setdefault('host', wazo_host)
 
-    config['ari']['base_url'] = f'http://{wazo_host}:5039'
+    ari_host = config['ari'].pop('host')
+    config['ari']['base_url'] = f"http://{ari_host}:5039"

--- a/wazo_acceptance/helpers/provd.py
+++ b/wazo_acceptance/helpers/provd.py
@@ -48,7 +48,7 @@ class Provd:
             )
 
     def create_device_via_http_request(self, path, user_agent, mac=None):
-        host = self._context.wazo_config['wazo_host']
+        host = self._context.wazo_config['provd']['provisioning_host']
         url = f'http://{host}:8667/{path}'
         requests.get(url, headers={'User-Agent': user_agent})
         if mac:

--- a/wazo_acceptance/setup.py
+++ b/wazo_acceptance/setup.py
@@ -148,10 +148,7 @@ def setup_config(context, config):
 
 @debug.logcall
 def setup_ssh_client(context):
-    context.ssh_client = SSHClient(
-        hostname=context.wazo_config['wazo_host'],
-        login=context.wazo_config['ssh_login'],
-    )
+    context.ssh_client = SSHClient(**context.wazo_config['ssh'])
 
 
 class Helpers:

--- a/wazo_acceptance/ssh.py
+++ b/wazo_acceptance/ssh.py
@@ -27,8 +27,8 @@ class SSHClient:
 
     _fobj_devnull = open(os.devnull, 'r+')
 
-    def __init__(self, hostname, login):
-        self._hostname = hostname
+    def __init__(self, host, login):
+        self._hostname = host
         self._login = login
 
     def send_files(self, path_from, path_to):

--- a/wazo_acceptance/steps/device.py
+++ b/wazo_acceptance/steps/device.py
@@ -33,21 +33,21 @@ def when_the_following_devices_are_created_via_http_requets_to_the_provisioning_
 
 @then('the following provisioning files are available over HTTP using port "{port}"')
 def then_the_following_provisioning_files_are_available_over_http_using_port(context, port):
-    host = context.wazo_config['wazo_host']
+    host = context.wazo_config['provd']['provisioning_host']
     base_url = f"http://{host}:{port}"
     _provisioning_files_are_available(context, base_url)
 
 
 @then('the following provisioning files are available over HTTPS')
 def then_the_following_provisioning_files_are_available_over_https(context):
-    host = context.wazo_config['wazo_host']
+    host = context.wazo_config['provd']['provisioning_host']
     base_url = f"https://{host}/device/provisioning"
     _provisioning_files_are_available(context, base_url)
 
 
 @then('the following provisioning files are available over HTTPS using provisioning key "{provisioning_key}"')
 def then_the_following_provisioning_files_are_available_over_https_using_key(context, provisioning_key):
-    host = context.wazo_config['wazo_host']
+    host = context.wazo_config['provd']['provisioning_host']
     base_url = f"https://{host}/device/provisioning/{provisioning_key}"
     _provisioning_files_are_available(context, base_url)
 


### PR DESCRIPTION
why: This is useful when the stack is behind a proxy (for API and SIP),
but you still want to execute SSH command and access to specific/custom
port on the stack (for ari and rabbitmq)