### PR TITLE
ensure-recent-pip-version

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -29,6 +29,7 @@ set +x
 source $VENV/bin/activate
 set -x
 pip install wheel
+pip install -U pip
 
 pip install -r requirements.txt
 pip install coverage[toml]


### PR DESCRIPTION
why: do not rely on jenkins pip version
Current acceptance-ci pip version is 20.3.4 which seems incompatible
with the latest setuptools (80)
Using more recent pip version fix the issue
