### PR TITLE
ITEM-92: Add missing queue/group var

### DIFF
--- a/features/daily/call_record.feature
+++ b/features/daily/call_record.feature
@@ -57,8 +57,8 @@ Feature: Call Record
       | User      | 801      | no                                    | 1801  | default | yes        |
       | User      | 802      | yes                                   | 1802  | default | yes        |
     Given there are telephony groups with infos:
-      | label      | exten | context |
-      | incoming   |  2514 | default |
+      | label      | exten | context | dtmf_record_toggle |
+      | incoming   |  2514 | default | yes                |
     Given the telephony group "incoming" has users:
       | firstname | lastname |
       | User      | Hall     |
@@ -115,8 +115,8 @@ Feature: Call Record
       | User      | 802      | yes                                   | 1802  | default | yes        | 1234         |
     Given agent "1234" is logged
     Given there are queues with infos:
-      | name       | exten | context |
-      | incoming   |  3123 | default |
+      | name       | exten | context | dtmf_record_toggle |
+      | incoming   |  3123 | default | yes                |
     Given the queue "incoming" has users:
       | firstname | lastname |
       | User      | Lee      |


### PR DESCRIPTION
WP-2020

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts feature fixtures; low risk aside from potentially changing which recording scenarios now pass/fail.
> 
> **Overview**
> Updates `features/daily/call_record.feature` so the group and queue setup tables in the *answerer-recorded* scenarios include `dtmf_record_toggle: yes`.
> 
> This aligns the test fixtures with expected telephony configuration for recording behavior in group/queue calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4bc1e1a29f58dc44b024ac3b2e11067141a84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->