### PR TITLE
[ITEM-92] Revert "recording: Add dtmf_toggle_recording var"

### DIFF
--- a/features/daily/call_record.feature
+++ b/features/daily/call_record.feature
@@ -57,8 +57,8 @@ Feature: Call Record
       | User      | 801      | no                                    | 1801  | default | yes        |
       | User      | 802      | yes                                   | 1802  | default | yes        |
     Given there are telephony groups with infos:
-      | label      | exten | context | dtmf_record_toggle |
-      | incoming   |  2514 | default | yes                |
+      | label      | exten | context |
+      | incoming   |  2514 | default |
     Given the telephony group "incoming" has users:
       | firstname | lastname |
       | User      | Hall     |
@@ -115,8 +115,8 @@ Feature: Call Record
       | User      | 802      | yes                                   | 1802  | default | yes        | 1234         |
     Given agent "1234" is logged
     Given there are queues with infos:
-      | name       | exten | context | dtmf_record_toggle |
-      | incoming   |  3123 | default | yes                |
+      | name       | exten | context |
+      | incoming   |  3123 | default |
     Given the queue "incoming" has users:
       | firstname | lastname |
       | User      | Lee      |


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-calld/pull/402
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tweaks Gherkin acceptance-test fixtures by removing `dtmf_record_toggle` from specific group/queue setup tables, with no production code changes.
> 
> **Overview**
> Reverts the acceptance-test setup for **group** and **queue** call recording scenarios to no longer specify `dtmf_record_toggle` when creating the `incoming` group/queue.
> 
> This aligns the tests with the prior recording behavior expected by `features/daily/call_record.feature` (recording based on caller/answerer configuration, not DTMF toggle config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381bda1d888d897cff78fdf9559696d49de73d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->