### PR TITLE
feat(pstn-fallback): add acceptance test and mobile_fallback_enabled helper

### DIFF
--- a/features/daily/pstn_mobile_fallback.feature
+++ b/features/daily/pstn_mobile_fallback.feature
@@ -1,0 +1,33 @@
+Feature: PSTN mobile fallback
+
+  Scenario: PSTN fallback call is triggered when push notification is not answered in time
+    Given there are telephony users with infos:
+      | firstname | lastname | exten | context | with_phone | username | password | ring_seconds | mobile_phone_number | mobile_fallback_enabled |
+      | Rick      | Grimes   |       |         |            | rick     | gR1m3    | 20           | 1803                | yes                     |
+      | Daryl     | Dixon    | 1802  | default | yes        | daryl    | d1x0N    |              |                     |                         |
+      | Carol     | Peletier | 1803  | default | yes        |          |          |              |                     |                         |
+    Given "Rick Grimes" has lines:
+      | name  | exten | context | with_phone | webrtc |
+      | rick1 | 1801  | default | yes        | no     |
+      | rick2 | 1801  | default | no         | yes    |
+    Given I create a mobile session with username "rick" password "gR1m3"
+    When "Daryl Dixon" calls "1801"
+    Then "Rick Grimes" is ringing on its contact "1"
+    When I wait 12 seconds for the end of ringing time
+    Then "Carol Peletier" is ringing
+
+  Scenario: PSTN fallback is not triggered when mobile_fallback_enabled is false
+    Given there are telephony users with infos:
+      | firstname | lastname | exten | context | with_phone | username | password | ring_seconds |
+      | Rick      | Grimes   |       |         |            | rick     | gR1m3    | 20           |
+      | Daryl     | Dixon    | 1802  | default | yes        | daryl    | d1x0N    |              |
+      | Carol     | Peletier | 1803  | default | yes        |          |          |              |
+    Given "Rick Grimes" has lines:
+      | name  | exten | context | with_phone | webrtc |
+      | rick1 | 1801  | default | yes        | no     |
+      | rick2 | 1801  | default | no         | yes    |
+    Given I create a mobile session with username "rick" password "gR1m3"
+    When "Daryl Dixon" calls "1801"
+    Then "Rick Grimes" is ringing on its contact "1"
+    When I wait 12 seconds for the end of ringing time
+    Then "Carol Peletier" is not ringing

--- a/features/daily/pstn_mobile_fallback.feature
+++ b/features/daily/pstn_mobile_fallback.feature
@@ -18,10 +18,10 @@ Feature: PSTN mobile fallback
 
   Scenario: PSTN fallback is not triggered when mobile_fallback_enabled is false
     Given there are telephony users with infos:
-      | firstname | lastname | exten | context | with_phone | username | password | ring_seconds |
-      | Rick      | Grimes   |       |         |            | rick     | gR1m3    | 20           |
-      | Daryl     | Dixon    | 1802  | default | yes        | daryl    | d1x0N    |              |
-      | Carol     | Peletier | 1803  | default | yes        |          |          |              |
+      | firstname | lastname | exten | context | with_phone | username | password | ring_seconds | mobile_phone_number | mobile_fallback_enabled |
+      | Rick      | Grimes   |       |         |            | rick     | gR1m3    | 20           | 1803                | no                      |
+      | Daryl     | Dixon    | 1802  | default | yes        | daryl    | d1x0N    |              |                     |                         |
+      | Carol     | Peletier | 1803  | default | yes        |          |          |              |                     |                         |
     Given "Rick Grimes" has lines:
       | name  | exten | context | with_phone | webrtc |
       | rick1 | 1801  | default | yes        | no     |

--- a/wazo_acceptance/helpers/confd_user.py
+++ b/wazo_acceptance/helpers/confd_user.py
@@ -28,7 +28,7 @@ class ConfdUser:
                 body[field] = record_enabled == 'yes'
 
         mobile_fallback_enabled = body.pop('mobile_fallback_enabled', None)
-        if mobile_fallback_enabled is not None:
+        if mobile_fallback_enabled:
             body['mobile_fallback_enabled'] = mobile_fallback_enabled == 'yes'
 
         modules = {'dialplan': True, 'pjsip': True, 'queue': True}

--- a/wazo_acceptance/helpers/confd_user.py
+++ b/wazo_acceptance/helpers/confd_user.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from requests import HTTPError
@@ -26,6 +26,10 @@ class ConfdUser:
             record_enabled = body.pop(field, None)
             if record_enabled:
                 body[field] = record_enabled == 'yes'
+
+        mobile_fallback_enabled = body.pop('mobile_fallback_enabled', None)
+        if mobile_fallback_enabled is not None:
+            body['mobile_fallback_enabled'] = mobile_fallback_enabled == 'yes'
 
         modules = {'dialplan': True, 'pjsip': True, 'queue': True}
         wait_reload = self._context.helpers.bus.wait_for_asterisk_reload

--- a/wazo_acceptance/helpers/confd_user.py
+++ b/wazo_acceptance/helpers/confd_user.py
@@ -27,6 +27,10 @@ class ConfdUser:
             if record_enabled:
                 body[field] = record_enabled == 'yes'
 
+        mobile_phone_number = body.pop('mobile_phone_number', None)
+        if mobile_phone_number:
+            body['mobile_phone_number'] = mobile_phone_number
+
         mobile_fallback_enabled = body.pop('mobile_fallback_enabled', None)
         if mobile_fallback_enabled:
             body['mobile_fallback_enabled'] = mobile_fallback_enabled == 'yes'

--- a/wazo_acceptance/steps/user.py
+++ b/wazo_acceptance/steps/user.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import string
@@ -58,10 +58,10 @@ def given_there_are_telephony_users_with_infos(context):
         if body.get('context'):
             body['context'] = context.helpers.context.get_by(label=body['context'])['name']
 
-        confd_user = context.helpers.confd_user.create(body)
+        username = body.pop('username', None) or context.helpers.utils.random_string(10)
+        password = body.pop('password', None) or context.helpers.utils.random_string(10, sample=string.printable)
 
-        username = body.get('username') or context.helpers.utils.random_string(10)
-        password = body.get('password') or context.helpers.utils.random_string(10, sample=string.printable)
+        confd_user = context.helpers.confd_user.create(body)
         firstname = body['firstname']
         lastname = body.get('lastname', '')
         user_body = {


### PR DESCRIPTION
Why: validates end-to-end PSTN fallback via a new Behave scenario that
checks Carol rings (or doesn't) after push notification times out.
The confd_user helper now coerces 'yes'/'no' strings to booleans for the
mobile_fallback_enabled field.

Depends-On: https://github.com/wazo-platform/wazo-calld/pull/403
Depends-On: https://github.com/wazo-platform/wazo-confd/pull/566
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/344
Depends-On: https://github.com/wazo-platform/xivo-manage-db/pull/342