### PR TITLE
DO NOT MERGE: Run the acceptance suite against a wazo-auth HTTP worker

### DIFF
--- a/features/daily/auth_http_worker.feature
+++ b/features/daily/auth_http_worker.feature
@@ -1,0 +1,7 @@
+Feature: wazo-auth HTTP workers
+
+  Scenario: the HTTP worker serves requests without running background jobs
+    Given an HTTP worker is running
+    When I send 50 requests to the local auth API
+    Then the HTTP worker served at least one request
+    And the HTTP worker does not run the expired-token remover

--- a/wazo_acceptance/auth_worker.py
+++ b/wazo_acceptance/auth_worker.py
@@ -1,0 +1,40 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+
+from wazo_test_helpers import until
+
+logger = logging.getLogger(__name__)
+
+WORKER_INSTANCE = 'wazo-auth-worker@1'
+WORKER_UNIT_FILE = '/usr/lib/systemd/system/wazo-auth-worker@.service'
+REUSE_PORT_CONFIG = '/etc/wazo-auth/conf.d/50-reuse-port.yml'
+
+
+def is_available(context):
+    return context.remote_sysutils.path_exists(WORKER_UNIT_FILE)
+
+
+def is_active(context):
+    output = context.ssh_client.out_call(['systemctl', 'is-active', WORKER_INSTANCE])
+    return output.strip() == 'active'
+
+
+def enable(context):
+    sysutils = context.remote_sysutils
+    sysutils.write_content_file(REUSE_PORT_CONFIG, 'rest_api:\n  reuse_port: true\n')
+    # Restart the primary so it rebinds the port with SO_REUSEPORT before the
+    # worker binds the shared port; otherwise the worker fails with EADDRINUSE.
+    sysutils.restart_service('wazo-auth')
+    context.ssh_client.check_call(['systemctl', 'enable', '--now', WORKER_INSTANCE])
+    until.true(
+        is_active, context, tries=15, message='HTTP worker did not become active'
+    )
+    logger.info('wazo-auth HTTP worker %s enabled', WORKER_INSTANCE)
+
+
+def disable(context):
+    context.ssh_client.call(['systemctl', 'disable', '--now', WORKER_INSTANCE])
+    context.ssh_client.call(['rm', '-f', REUSE_PORT_CONFIG])
+    context.remote_sysutils.restart_service('wazo-auth')

--- a/wazo_acceptance/environment.py
+++ b/wazo_acceptance/environment.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from behave.runner import Context, ContextMode, use_context_with_mode
 from xivo.pubsub import Pubsub
 from xivo.xivo_logging import setup_logging as wazo_setup_logging
 
-from . import debug, setup
+from . import auth_worker, debug, setup
 from .config import load_config
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,19 @@ class InstanceContext:
 def before_all(context: Context) -> None:
     initialize(context)
     context.fail_on_cleanup_errors = False
+    if auth_worker.is_available(context):
+        auth_worker.enable(context)
+    else:
+        logger.warning(
+            'wazo-auth does not ship the HTTP worker unit; '
+            'running the suite without a worker'
+        )
+
+
+# Implicitly defined by behave
+def after_all(context: Context) -> None:
+    if getattr(context, 'remote_sysutils', None) and auth_worker.is_available(context):
+        auth_worker.disable(context)
 
 
 # Implicitly defined by behave

--- a/wazo_acceptance/steps/__init__.py
+++ b/wazo_acceptance/steps/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .agent import *  # noqa
@@ -6,6 +6,7 @@ from .application import *  # noqa
 from .assets import *  # noqa
 from .asterisk import *  # noqa
 from .auth import *  # noqa
+from .auth_http_worker import *  # noqa
 from .backup import *  # noqa
 from .blocklist import *  # noqa
 from .bus import *  # noqa

--- a/wazo_acceptance/steps/auth_http_worker.py
+++ b/wazo_acceptance/steps/auth_http_worker.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from behave import given, then, when
+from wazo_test_helpers import until
+
+from .. import auth_worker
+
+# Hit wazo-auth directly (not through nginx, whose upstream keep-alive would
+# pin requests to a single instance and hide the SO_REUSEPORT load-balancing).
+LOCAL_AUTH_URL = 'http://127.0.0.1:9497/0.1/backends'
+REMOVER_LOG = 'ExpiredTokenRemover took'
+
+
+@given('an HTTP worker is running')
+def given_an_http_worker_is_running(context):
+    if not auth_worker.is_available(context):
+        context.scenario.skip('wazo-auth does not ship the HTTP worker unit')
+        return
+    assert auth_worker.is_active(context), 'the HTTP worker is not running'
+
+
+@when('I send {count:d} requests to the local auth API')
+def when_i_send_requests_to_local_auth(context, count):
+    context.worker_requests_since = context.ssh_client.out_call(['date', '+%s']).strip()
+    burst = (
+        f'for i in $(seq {count}); do '
+        f'curl -s -o /dev/null -H "Connection: close" {LOCAL_AUTH_URL}; done'
+    )
+    context.ssh_client.check_call([burst])
+
+
+@then('the HTTP worker served at least one request')
+def then_the_worker_served_a_request(context):
+    since = context.worker_requests_since
+
+    def _worker_logged_request():
+        logs = context.ssh_client.out_call(
+            [f'journalctl --no-pager -u {auth_worker.WORKER_INSTANCE} --since=@{since}']
+        )
+        return '/0.1/backends' in logs
+
+    until.true(
+        _worker_logged_request,
+        tries=15,
+        message='the HTTP worker never served a request',
+    )
+
+
+@then('the HTTP worker does not run the expired-token remover')
+def then_worker_does_not_run_remover(context):
+    logs = context.ssh_client.out_call(
+        [f'journalctl --no-pager -u {auth_worker.WORKER_INSTANCE}']
+    )
+    assert REMOVER_LOG not in logs, 'the HTTP worker must not run the ExpiredTokenRemover'


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-auth/pull/444

## Purpose

Temporary, throwaway branch to validate that wazo-platform/wazo-auth#444
(horizontal scaling of wazo-auth via `--http-worker` + `SO_REUSEPORT`)
introduces **no regression** when the stack actually runs behind a
load-balanced HTTP worker.
**Not for merge.** Once #444 is validated, this branch is discarded.

## What it does

- `before_all` enables a wazo-auth HTTP worker for the whole run: writes a
  `rest_api.reuse_port: true` drop-in, restarts the primary so it rebinds
  with `SO_REUSEPORT`, then `systemctl enable --now wazo-auth-worker@1`.
  `after_all` tears it down. Every scenario therefore exercises the
  load-balanced topology, so a regression surfaces anywhere in the suite —
  not only in auth tests.
- If the installed wazo-auth does not ship the worker unit, enabling is
  skipped (logged) and the suite runs single-instance, so the job degrades
  gracefully on stacks without the feature.
- Adds one dedicated scenario (`features/daily/auth_http_worker.feature`)
  proving the worker isn't silently idle: a direct request burst to
  `127.0.0.1:9497` (bypassing nginx upstream keep-alive) confirms it serves
  traffic, and its journal confirms it never runs the `ExpiredTokenRemover`.

## How to read the results

- A failure in **any** feature points at worker-induced behavior — most
  likely something relying on per-process in-memory state (e.g. the known
  `PATCH /0.1/config` limitation, documented in #444).
- If the dedicated scenario is **skipped**, the installed wazo-auth lacked
  the worker unit — check that the `Depends-On` build was actually installed.

## Scope / limitations

- Enables the worker on the **default** engine only (single-instance);
  an HA/multi-instance topology would need per-instance enabling.
- One replica (`wazo-auth-worker@1`) is enough to prove the load-balanced path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only acceptance harness changes; no production auth or runtime behavior is modified in this repo.
> 
> **Overview**
> Adds acceptance-suite support to exercise **wazo-auth** behind an HTTP worker (`SO_REUSEPORT` + `wazo-auth-worker@1`) for pre-merge validation of horizontal scaling.
> 
> **Suite-wide setup:** `before_all` enables the worker when the systemd unit exists (writes `rest_api.reuse_port: true`, restarts primary, starts `wazo-auth-worker@1`); `after_all` disables it. Stacks without the unit log a warning and run single-instance.
> 
> **Dedicated scenario** (`auth_http_worker.feature`): direct bursts to `127.0.0.1:9497` (bypassing nginx keep-alive) assert the worker serves traffic and does **not** run `ExpiredTokenRemover`.
> 
> New helpers: `auth_worker.py` (enable/disable/availability) and Behave steps in `auth_http_worker.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65074ab214866b6a0aaa56f94071fb087fa2bfe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->