### PR TITLE
voicemails: add test with email address on voicemail

### DIFF
--- a/features/daily/voicemail.feature
+++ b/features/daily/voicemail.feature
@@ -13,6 +13,19 @@ Feature: Voicemail
       | caller_id_name | folder_name | folder_type |
       | Billy          | inbox       | new         |
 
+  Scenario: Leave voicemail message with email on voicemail
+    Given there are telephony users with infos:
+      | firstname | lastname | number | context | voicemail_name | voicemail_number | voicemail_context | voicemail_email  |
+      | George    | Hanson   | 1801   | default | George Hanson  | 1801             | default           | test@example.com |
+    Given I listen on the bus for "user_voicemail_message_created" messages
+    When a message is left on voicemail "1801@default" by "Billy"
+    Then I receive a "user_voicemail_message_created" event with "message" data:
+      | caller_id_name | folder_name | folder_type |
+      | Billy          | inbox       | new         |
+    Then there's the following messages in voicemail "1801@default"
+      | caller_id_name | folder_name | folder_type |
+      | Billy          | inbox       | new         |
+
   Scenario: Check voicemail message
     Given there are telephony users with infos:
       | firstname | lastname | number | context | voicemail_name | voicemail_number | voicemail_context |

--- a/wazo_acceptance/steps/user.py
+++ b/wazo_acceptance/steps/user.py
@@ -121,11 +121,13 @@ def given_there_are_telephony_users_with_infos(context):
         if (body.get('voicemail_name')
                 and body.get('voicemail_number')
                 and body.get('voicemail_context')):
+            voicemail_email_address = body.get('voicemail_email')
             voicemail_context = context.helpers.context.get_by(label=body['voicemail_context'])['name']
             voicemail = context.helpers.voicemail.create({
                 'name': body['voicemail_name'],
                 'context': voicemail_context,
-                'number': body['voicemail_number']
+                'number': body['voicemail_number'],
+                'email': voicemail_email_address,
             })
             context.helpers.confd_user.add_voicemail(confd_user, voicemail)
 


### PR DESCRIPTION
Why: asterisk crashes were caused by this
Depends-On: https://github.com/wazo-platform/asterisk/pull/194

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Gherkin scenarios and test step wiring; no production telephony or voicemail runtime code is modified.
> 
> **Overview**
> Adds acceptance coverage for **voicemails that have an email address**, matching a case that previously triggered Asterisk crashes.
> 
> The `there are telephony users with infos` step now accepts an optional **`voicemail_email`** column and passes it through to **`voicemail.create`** when provisioning the mailbox. A new daily scenario mirrors the existing “leave voicemail message” flow but provisions **`test@example.com`** on the mailbox and asserts the same bus events and inbox message state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f61a0d2808cb79922486a9e6d59d72fe4127f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->