### PR TITLE
DO NOT MERGE: acceptance run for TASK-504 (internal requests through nginx)

### DIFF
--- a/TASK-504-acceptance-run.md
+++ b/TASK-504-acceptance-run.md
@@ -1,0 +1,9 @@
+# TASK-504 acceptance run — DO NOT MERGE
+
+This file exists only to carry a pull request whose `Depends-On:` lines make
+Zuul build and install every TASK-504 change on the acceptance stack, so the
+daily features run against services configured to reach wazo-auth through
+nginx (`localhost:80`, prefix `/api/auth`) instead of `localhost:9497`.
+
+Delete the branch once the run has been read. Nothing here should ever land on
+master.


### PR DESCRIPTION
**DO NOT MERGE** — throwaway PR to run `wazo-acceptance-bookworm` against the
whole TASK-504 set.

The acceptance job builds a package for every item in the Zuul queue
(`debian-packaging` role loops over `zuul.items`), so the `Depends-On:` lines
below put all the TASK-504 changes on the stack: services then reach wazo-auth
through nginx on `localhost:80` with prefix `/api/auth` instead of hitting
`localhost:9497` directly.

Scope note: only `wazo-platform` PRs are listed. `TinxHQ/wazo-lookupd#10` and
`wazo-communication/wazo-audit-plugin#37` are part of TASK-504 but are not
installed by the acceptance stack.

`wazo-auth#449` targets `role-based-controller`, so the auth package built here
also contains PR #448 (the multi-process scaling work) — that branch is where
the `upstream wazo-auth` block lives, and the internal location needs it. #448
is therefore not listed separately.

Depends-On: https://github.com/wazo-platform/wazo-nginx/pull/23
Depends-On: https://github.com/wazo-platform/wazo-auth/pull/449
Depends-On: https://github.com/wazo-platform/wazo-agentd/pull/150
Depends-On: https://github.com/wazo-platform/wazo-agid/pull/215
Depends-On: https://github.com/wazo-platform/wazo-amid/pull/114
Depends-On: https://github.com/wazo-platform/wazo-calld/pull/415
Depends-On: https://github.com/wazo-platform/wazo-call-logd/pull/297
Depends-On: https://github.com/wazo-platform/wazo-chatd/pull/206
Depends-On: https://github.com/wazo-platform/wazo-confd/pull/571
Depends-On: https://github.com/wazo-platform/wazo-dird/pull/266
Depends-On: https://github.com/wazo-platform/wazo-phoned/pull/124
Depends-On: https://github.com/wazo-platform/wazo-plugind/pull/104
Depends-On: https://github.com/wazo-platform/wazo-provd/pull/152
Depends-On: https://github.com/wazo-platform/wazo-setupd/pull/95
Depends-On: https://github.com/wazo-platform/wazo-stat/pull/48
Depends-On: https://github.com/wazo-platform/wazo-ui/pull/215
Depends-On: https://github.com/wazo-platform/wazo-webhookd/pull/252
Depends-On: https://github.com/wazo-platform/wazo-websocketd/pull/104
Depends-On: https://github.com/wazo-platform/wazo-dxtora/pull/32
Depends-On: https://github.com/wazo-platform/wazo-debug/pull/45
Depends-On: https://github.com/wazo-platform/wazo-upgrade/pull/110
Depends-On: https://github.com/wazo-platform/wazo-agentd-cli/pull/33
Depends-On: https://github.com/wazo-platform/wazo-asterisk-cli/pull/14
Depends-On: https://github.com/wazo-platform/wazo-auth-cli/pull/46
Depends-On: https://github.com/wazo-platform/wazo-plugind-cli/pull/29
Depends-On: https://github.com/wazo-platform/wazo-provd-cli/pull/23
Depends-On: https://github.com/wazo-platform/wazo-export-import/pull/17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with explicit do-not-merge intent; no runtime or security behavior changes in this diff.
> 
> **Overview**
> Adds **`TASK-504-acceptance-run.md`**, a **DO NOT MERGE** marker doc for a coordination-only pull request. The PR itself does not change product code; it exists so Zuul can honor the long **`Depends-On:`** list in the description and build/install the full TASK-504 stack for **`wazo-acceptance-bookworm`**.
> 
> The stated goal is to run daily features against services that reach **wazo-auth via nginx** (`localhost:80`, `/api/auth`) instead of **`localhost:9497`**. The file instructs deleting the branch after the run and keeping this off **master**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8daeb3d5e7b24d470014b8c67a96c73b3c57e1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->